### PR TITLE
fix: Replace legacy method

### DIFF
--- a/.changeset/cool-shoes-visit.md
+++ b/.changeset/cool-shoes-visit.md
@@ -1,0 +1,5 @@
+---
+"@bnb-chain/greenfield-js-sdk": patch
+---
+
+fix: Replace legacy method, Some third-party plug-ins (e.g. wallet guard) will automatically convert deprecated methods and are not compatible with the return value of deprecated methods. https://github.com/wallet-guard/wallet-guard-extension/blob/221ad3eb329ad7681b16a37c7ddfaf173dba6e7f/src/injected/injectWalletGuard.tsx#L49-L62

--- a/packages/js-sdk/src/clients/spclient/sign.ts
+++ b/packages/js-sdk/src/clients/spclient/sign.ts
@@ -22,12 +22,10 @@ const signMessagePersonalAPI = async (
   message: Uint8Array,
   address: string,
 ): Promise<string> => {
-  return provider.send('personal_sign', [hexlify(message), address]).then(
-    (sign: string) => sign,
-    (err: Error) => {
-      throw err;
-    },
-  );
+  return provider.request({
+    method: 'personal_sign',
+    params: [hexlify(message), address],
+  });
 };
 
 const generateSeed = async (
@@ -36,7 +34,7 @@ const generateSeed = async (
 ) => {
   const signedBytes = typeof message === 'string' ? toUtf8Bytes(message) : arrayify(message);
   const res = (await signMessagePersonalAPI(provider, signedBytes, address)) as any;
-  const seed = arrayify(res?.result);
+  const seed = arrayify(res);
 
   return { seed };
 };


### PR DESCRIPTION
## Description

Some third-party plug-ins (e.g. wallet guard) will automatically convert deprecated methods and are not compatible with the return value of deprecated methods.

https://github.com/wallet-guard/wallet-guard-extension/blob/221ad3eb329ad7681b16a37c7ddfaf173dba6e7f/src/injected/injectWalletGuard.tsx#L49-L62
## Rationale

tell us why we need these changes...

## Example

add an example CLI or API response...

## Changes

Notable changes:

* add each change in a bullet point here
* ...
