### PR TITLE
fix: Avoid object override

### DIFF
--- a/.changeset/smart-pumpkins-cross.md
+++ b/.changeset/smart-pumpkins-cross.md
@@ -1,0 +1,5 @@
+---
+'@bnb-chain/greenfield-js-sdk': patch
+---
+
+fix: Avoid Object override

--- a/packages/js-sdk/src/clients/spclient/spApis/getObjectMeta.ts
+++ b/packages/js-sdk/src/clients/spclient/spApis/getObjectMeta.ts
@@ -31,19 +31,19 @@ export const parseGetObjectMetaResponse = async (data: string) => {
   });
   const res = xmlParser.parse(data) as GetObjectMetaResponse;
 
-  const Object = res.GfSpGetObjectMetaResponse.Object || {};
-  if (Object) {
+  const ObjectTmp = res.GfSpGetObjectMetaResponse.Object || {};
+  if (ObjectTmp) {
     // @ts-ignore
-    Object.Removed = convertStrToBool(Object.Removed);
-    Object.UpdateAt = Number(Object.UpdateAt);
-    Object.DeleteAt = Number(Object.DeleteAt);
+    ObjectTmp.Removed = convertStrToBool(ObjectTmp.Removed);
+    ObjectTmp.UpdateAt = Number(ObjectTmp.UpdateAt);
+    ObjectTmp.DeleteAt = Number(ObjectTmp.DeleteAt);
 
-    Object.ObjectInfo = formatObjectInfo(Object.ObjectInfo);
+    ObjectTmp.ObjectInfo = formatObjectInfo(ObjectTmp.ObjectInfo);
   }
 
   res.GfSpGetObjectMetaResponse = {
     ...res.GfSpGetObjectMetaResponse,
-    Object,
+    Object: ObjectTmp,
   };
 
   return res;


### PR DESCRIPTION
## Description

Avoiding `Object` override on Nodejs.

