### PR TITLE
feat: DelegatedCreateFolder api

### DIFF
--- a/.changeset/eleven-dragons-report.md
+++ b/.changeset/eleven-dragons-report.md
@@ -1,0 +1,5 @@
+---
+'@bnb-chain/greenfield-js-sdk': major
+---
+
+feat: Support delegatedCreateFolder

--- a/examples/nextjs/src/components/object/create/index.tsx
+++ b/examples/nextjs/src/components/object/create/index.tsx
@@ -323,6 +323,40 @@ export const CreateObject = () => {
           }}
         >
           create folder
+        </button>{' '}
+        <button
+          onClick={async () => {
+            if (!address) return;
+
+            const provider = await connector?.getProvider();
+            const offChainData = await getOffchainAuthKeys(address, provider);
+            if (!offChainData) {
+              alert('No offchain, please create offchain pairs first');
+              return;
+            }
+
+            const res = await client.object.delegateCreateFolder(
+              {
+                bucketName: createObjectInfo.bucketName,
+                objectName: createObjectInfo.objectName,
+                delegatedOpts: {
+                  visibility: VisibilityType.VISIBILITY_TYPE_PUBLIC_READ,
+                },
+              },
+              {
+                type: 'EDDSA',
+                domain: window.location.origin,
+                seed: offChainData.seedString,
+                address,
+              },
+            );
+
+            if (res.code === 0) {
+              alert('success');
+            }
+          }}
+        >
+          delegate create folder
         </button>
       </>
     </div>

--- a/packages/js-sdk/src/clients/spclient/spApis/delegatedCreateFolder.ts
+++ b/packages/js-sdk/src/clients/spclient/spApis/delegatedCreateFolder.ts
@@ -1,0 +1,52 @@
+import { EMPTY_STRING_SHA256, METHOD_POST } from '@/constants';
+import { ReqMeta } from '@/types';
+import { generateUrlByBucketName } from '@/utils';
+import { VisibilityType } from '@bnb-chain/greenfield-cosmos-types/greenfield/storage/common';
+import { encodePath, getSortQueryParams } from '../auth';
+
+export const getDelegatedCreateFolderMetaInfo = async (
+  endpoint: string,
+  params: {
+    objectName: string;
+    bucketName: string;
+    delegatedOpts?: {
+      visibility: VisibilityType;
+    };
+  },
+) => {
+  const { bucketName, objectName, delegatedOpts } = params;
+  const path = `/${encodePath(objectName)}`;
+  let queryMap = {};
+
+  if (delegatedOpts) {
+    queryMap = {
+      'create-folder': '',
+      payload_size: '0',
+      visibility: delegatedOpts.visibility.toString(),
+    };
+  }
+
+  let url = new URL(path, generateUrlByBucketName(endpoint, bucketName));
+  url = getSortQueryParams(url, queryMap);
+
+  const reqMeta: Partial<ReqMeta> = {
+    contentSHA256: EMPTY_STRING_SHA256,
+    method: METHOD_POST,
+    url: {
+      hostname: url.hostname,
+      query: url.searchParams.toString(),
+      path,
+    },
+    contentType: '',
+  };
+
+  const optionsWithOutHeaders: Omit<RequestInit, 'headers'> = {
+    method: METHOD_POST,
+  };
+
+  return {
+    url: url.href,
+    optionsWithOutHeaders,
+    reqMeta,
+  };
+};

--- a/packages/js-sdk/src/types/sp/PutObject.ts
+++ b/packages/js-sdk/src/types/sp/PutObject.ts
@@ -21,6 +21,14 @@ export type DelegatedPubObjectRequest = {
   resumableOpts?: ResumableOpts;
 };
 
+export type DelegatedCreateFolderRequest = {
+  bucketName: string;
+  objectName: string;
+  delegatedOpts: DelegatedOpts;
+  endpoint?: string;
+  timeout?: number;
+};
+
 export type DelegatedOpts = {
   visibility: VisibilityType;
   isUpdate?: boolean;


### PR DESCRIPTION
## Description

Add `object.delegateCreateFolder` api


## Example

```js
await client.object.delegateCreateFolder(
  {
    bucketName: createObjectInfo.bucketName,
    objectName: createObjectInfo.objectName,
    delegatedOpts: {
      visibility: VisibilityType.VISIBILITY_TYPE_PUBLIC_READ,
    },
  },
  {
    type: 'EDDSA',
    domain: window.location.origin,
    seed: offChainData.seedString,
    address,
  },
);
```
