### PR TITLE
fix: EncodePath utf8

### DIFF
--- a/.changeset/perfect-panthers-add.md
+++ b/.changeset/perfect-panthers-add.md
@@ -1,0 +1,5 @@
+---
+'@bnb-chain/greenfield-js-sdk': patch
+---
+
+feat: EncodePath UTF-8

--- a/packages/js-sdk/tests/utils.spec.ts
+++ b/packages/js-sdk/tests/utils.spec.ts
@@ -12,6 +12,12 @@ describe('encodePaths', () => {
 
   it('encode chinese chars', () => {
     expect(encodePath('中文')).equals('%E4%B8%AD%E6%96%87');
+
+    expect(encodePath('·')).equals('%C2%B7');
+
+    expect(encodePath('。，！·#@……*？《》+')).equals(
+      '%E3%80%82%EF%BC%8C%EF%BC%81%C2%B7%23%40%E2%80%A6%E2%80%A6%2A%EF%BC%9F%E3%80%8A%E3%80%8B%2B',
+    );
   });
 
   it('encode complex utf-8 chars', () => {


### PR DESCRIPTION
## Description

* `encodePath` Chinese in UTF-8

## Example

[utils.spec.ts](https://github.com/bnb-chain/greenfield-js-sdk/blob/efc4654190e603b43b69d49b561d9386584f256a/packages/js-sdk/tests/utils.spec.ts)


## Changes

Notable changes:

* No chanages in API
